### PR TITLE
Remove link URLs from the Markdown used for page extraction

### DIFF
--- a/src/controller/service.ts
+++ b/src/controller/service.ts
@@ -1007,7 +1007,23 @@ export class Controller<Context = any> {
           // Remove script, style, and other non-content tags
           // This matches the behavior of Python's markdownify
           // The .remove() method ensures these tags and their contents are completely removed
-          turndownService.remove(['script', 'style', 'meta', 'link', 'noscript']);
+          turndownService.remove([
+            "script",
+            "style",
+            "meta",
+            "link",
+            "noscript",
+            "img",
+          ]);
+  
+          // Remove link URLs, but keep the text
+          turndownService.addRule("plainLink", {
+            filter: "a",
+  
+            replacement(content) {
+              return content; // no Markdown URL, just the text
+            },
+          });
           
           // Convert HTML to markdown
           const content = turndownService.turndown(pageContent);


### PR DESCRIPTION
Thanks for your work on this!

The original Python library doesn't include image tags in the Markdown passed to the page extraction LLM, nor does it include the `href` URLs for `a` tags. 

This tiny PR makes the TypeScript library behave the same way, which results in around a 3x reduction in page extraction token usage in my tests, and solves the 4o token limit error when running the included shopping example.