### PR TITLE
Change Agent class constructor to use options pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 build/
 lib/
 
+# Screenshots
+screenshot*
+
 # Logs
 logs
 *.log

--- a/examples/search.ts
+++ b/examples/search.ts
@@ -2,11 +2,17 @@
  * Example of using the browser-use Agent with TypeScript
  * Based on the Python implementation at https://github.com/browser-use/browser-use/blob/main/examples/use-cases/captcha.py
  */
-import { Agent, Browser, BrowserConfig } from '../src';
+import {
+  Agent,
+  Browser,
+  BrowserConfig,
+  BrowserContext,
+  BrowserContextConfig,
+} from "../src";
 // Import LangChain components
-import { ChatOpenAI } from '@langchain/openai';
+import { ChatOpenAI } from "@langchain/openai";
 // For loading environment variables, matching Python's dotenv
-import * as dotenv from 'dotenv';
+import * as dotenv from "dotenv";
 
 // Load environment variables from .env file - exact match with Python
 dotenv.config();
@@ -26,10 +32,10 @@ const browserConfig = new BrowserConfig({
   headless: false,
   disableSecurity: true,
   args: [
-    '--disable-blink-features=AutomationControlled',
-    '--disable-features=IsolateOrigins,site-per-process',
-    '--disable-site-isolation-trials'
-  ]
+    "--disable-blink-features=AutomationControlled",
+    "--disable-features=IsolateOrigins,site-per-process",
+    "--disable-site-isolation-trials",
+  ],
 });
 
 const browser = new Browser(browserConfig);
@@ -38,47 +44,25 @@ const browser = new Browser(browserConfig);
 const agent = new Agent(
   task,
   new ChatOpenAI({
-    openAIApiKey: process.env['OPENAI_API_KEY'] || '', // Provide empty string as fallback
-    modelName: 'gpt-4o',
+    openAIApiKey: process.env["OPENAI_API_KEY"] || "", // Provide empty string as fallback
+    modelName: "gpt-4o",
     temperature: 0.0, // Match exactly 0.0 as in Python
   }),
-  browser,            // Browser with optimized screenshot settings
-  undefined,          // browserContext
-  undefined,          // controller
-  undefined,          // sensitiveData
-  undefined,          // initialActions
-  undefined,          // registerNewStepCallback
-  undefined,          // registerDoneCallback
-  undefined,          // registerExternalAgentStatusRaiseErrorCallback
-  true,              // useVision - DISABLED to avoid context limit errors
-  true,              // useVisionForPlanner
-  undefined,          // saveConversationPath
-  undefined,          // saveConversationPathEncoding
-  undefined,          // maxFailures
-  undefined,          // retryDelay
-  undefined,          // overrideSystemMessage
-  undefined,          // extendSystemMessage
-  undefined,          // maxInputTokens
-  undefined,          // validateOutput
-  undefined,          // messageContext
-  undefined,          // generateGif
-  undefined,          // availableFilePaths
-  undefined,          // includeAttributes
-  undefined           // maxActionsPerStep
-  // Using default 'auto' tool calling method
+  {
+    browser: browser,
+  } // Options object
 );
-
 
 // Main function to run the agent
 async function main() {
   try {
     await agent.run();
-    
+
     // Add the "press enter to exit" functionality to match Python implementation
     // In Python: input('Press Enter to exit')
-    console.log('Press Enter to exit');
+    console.log("Press Enter to exit");
     await new Promise<void>((resolve) => {
-      process.stdin.once('data', () => {
+      process.stdin.once("data", () => {
         resolve();
       });
     });

--- a/examples/shopping-example.ts
+++ b/examples/shopping-example.ts
@@ -1,11 +1,18 @@
 /**
  * Example of using the browser-use Agent with OpenAI to execute a shopping task
  */
-import { Agent, Browser, BrowserConfig } from '../src';
+import {
+  Agent,
+  Browser,
+  BrowserContext,
+  BrowserContextConfig,
+  BrowserConfig,
+} from "../src"; // browser-use-ts
 // Import LangChain components
-import { ChatOpenAI } from '@langchain/openai';
+import { ChatOpenAI } from "@langchain/openai";
 // For loading environment variables, matching Python's dotenv
-import * as dotenv from 'dotenv';
+import * as dotenv from "dotenv";
+import { AgentHistoryList } from "../src/agent/views"; // Import AgentHistoryList correctly
 
 // Load environment variables from .env file - exact match with Python
 dotenv.config();
@@ -37,52 +44,67 @@ Visit Amazon.com, search for a laptop under $1000, and find the best option base
    - Why you selected it over others
 `;
 
-// Create a browser instance with non-headless mode to see what's happening
-const browser = new Browser(new BrowserConfig({
-  headless: false,
-  disableSecurity: true,
-  args: [
-    '--disable-blink-features=AutomationControlled',
-    '--disable-features=IsolateOrigins,site-per-process',
-    '--disable-site-isolation-trials'
-  ]
-}));
+// Create Browser instance first
+const browserInstance = new Browser(new BrowserConfig({ headless: false }));
+
+// Configure BrowserContext
+const browserContextConfig = new BrowserContextConfig({
+  // Set a user agent to mimic a real browser, which might help avoid bot detection
+  userAgent:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+  // Increase viewport size for potentially complex pages
+  viewport: { width: 1920, height: 1080 },
+});
+// Pass the created Browser instance to BrowserContext
+const browserContext = new BrowserContext(
+  browserInstance,
+  browserContextConfig
+);
 
 // Create the agent with vision turned off
 const agent = new Agent(
   task,
   new ChatOpenAI({
-    openAIApiKey: process.env['OPENAI_API_KEY'] || '',
-    modelName: 'gpt-4o',
-    temperature: 0.0,
+    openAIApiKey: process.env["OPENAI_API_KEY"] || "",
+    modelName: "gpt-4-turbo",
+    temperature: 0.1,
+    maxTokens: 1500, // Increased tokens for potentially longer pages
   }),
-  browser,
-  undefined,   // browserContext
-  undefined,   // controller
-  undefined,   // sensitiveData
-  undefined,   // initialActions
-  undefined,   // registerNewStepCallback
-  undefined,   // registerDoneCallback
-  undefined,   // registerExternalAgentStatusRaiseErrorCallback
-  true        // useVision - set to false to disable screenshots
+  // All other positional arguments moved to options
+  {
+    // Pass the pre-configured browserContext via options
+    browserContext: browserContext,
+    // Other options can be added here if needed, e.g.:
+    // useVision: true,
+    // maxFailures: 5
+  } // Options object
 );
 
 // Main function to run the agent
 async function main() {
   try {
-    await agent.run();
-    
-    // Add the "press enter to exit" functionality to match Python implementation
-    // In Python: input("Press Enter to close the browser...")
-    console.log('Press Enter to close the browser...');
-    await new Promise<void>((resolve) => {
-      process.stdin.once('data', () => {
-        resolve();
-      });
-    });
+    // Run the agent
+    const history: AgentHistoryList = await agent.run(15); // Increased max steps for shopping task
+
+    // Print the final result from the last history item
+    console.log("\nFinal Result:");
+    if (history && history.history.length > 0) {
+      const lastStep = history.history[history.history.length - 1];
+      // The result is an array of ActionResult, check the last one for done status/content
+      if (lastStep && lastStep.result && lastStep.result.length > 0) {
+        const lastActionResult = lastStep.result[lastStep.result.length - 1];
+        console.log(JSON.stringify(lastActionResult, null, 2));
+      } else {
+        console.log("Last step result not found.");
+      }
+    } else {
+      console.log("No history found.");
+    }
+  } catch (error) {
+    console.error("Error during agent execution:", error);
   } finally {
-    // Make sure to close the browser
-    await browser.close();
+    // Close the browser context (which should close the underlying browser instance)
+    await browserContext.close();
   }
 }
 

--- a/examples/simple-example.ts
+++ b/examples/simple-example.ts
@@ -1,35 +1,32 @@
-import { Agent, Browser, BrowserConfig } from '../src';
-import { ChatOpenAI } from '@langchain/openai';
-import * as dotenv from 'dotenv';
+import { Agent, Browser, BrowserConfig } from "../src";
+import { ChatOpenAI } from "@langchain/openai";
+import * as dotenv from "dotenv";
 
 dotenv.config();
 
 // Simple task to find the founders of browser-use
-const task = 'Navigate to the browser-use GitHub repository at https://github.com/browser-use/browser-use and find information about the project and its contributors';
+const task =
+  "Navigate to the browser-use GitHub repository at https://github.com/browser-use/browser-use and find information about the project and its contributors";
 
 // Create a browser instance with non-headless mode to see what's happening
-const browser = new Browser(new BrowserConfig({
-  headless: false,
-  disableSecurity: true
-}));
+const browser = new Browser(
+  new BrowserConfig({
+    headless: false,
+    disableSecurity: true,
+  })
+);
 
 // Create the agent with direct OpenAI implementation
 const agent = new Agent(
   task,
   new ChatOpenAI({
-    openAIApiKey: process.env['OPENAI_API_KEY'] || '',
-    modelName: 'gpt-4o',
+    openAIApiKey: process.env["OPENAI_API_KEY"] || "",
+    modelName: "gpt-4o",
     temperature: 0.0,
   }),
-  browser,
-  undefined,   // browserContext
-  undefined,   // controller
-  undefined,   // sensitiveData
-  undefined,   // initialActions
-  undefined,   // registerNewStepCallback
-  undefined,   // registerDoneCallback
-  undefined,   // registerExternalAgentStatusRaiseErrorCallback
-  true        // useVision - set to false to disable screenshots
+  {
+    browser: browser,
+  }
 );
 
 // Main function to run the agent


### PR DESCRIPTION
I don't know if you want these pull requests -- do by all means tell me to stop!

I had trouble remembering the Agent class syntax so took the liberty of changing the class constructor to use an options pattern, e.g.

```ts
const agent = new Agent(
  task,
  new ChatOpenAI({
    openAIApiKey: process.env["OPENAI_API_KEY"] || "",
    modelName: "gpt-4-turbo",
  }),
  // All other positional arguments moved to options
  {
    // Pass the pre-configured browserContext via options
    browserContext: browserContext,
    // Other options can be added here if needed, e.g.:
    // useVision: true,
    // maxFailures: 5,
  } // Options object
);
```

This makes the practical usage closer to the Python library.